### PR TITLE
Fix build in VS

### DIFF
--- a/browser/src/App.fs
+++ b/browser/src/App.fs
@@ -1,4 +1,5 @@
-module App
+module App.StartupObject
+
 open App.Model
 open Browser.Dom
 open Fable.Core


### PR DESCRIPTION
Not sure why, but without that fix I receive
```
error FS0247: A namespace and a module named 'App' both occur in two parts of this assembly
```