### PR TITLE
Added missing tool manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,4 +295,3 @@ __pycache__/
 *.xsd.cs
 
 .DS_Store
-.config

--- a/browser/.config/dotnet-tools.json
+++ b/browser/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fable": {
+      "version": "3.7.14",
+      "commands": [
+        "fable"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
`.config` was git ignored, which is important for `dotnet tool`s
Without tool manifest `dotnet tool restore` can't restore and use `fable`